### PR TITLE
IRQ disabling/enabling is tight to the spinlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,24 @@
 [package]
 name = "ruspiro-singleton"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.2.0" # remember to update html_root_url
+version = "0.2.1" # remember to update html_root_url
 description = "Simple and easy to use singleton pattern"
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-singleton/tree/v0.2.0"
-documentation = "https://docs.rs/ruspiro-singleton/0.2.0"
+repository = "https://github.com/RusPiRo/ruspiro-singleton"
+documentation = "https://docs.rs/ruspiro-singleton/0.2.1"
 readme = "README.md"
 keywords = ["RusPiRo", "singleton", "raspberrypi"]
 categories = ["no-std", "embedded"]
 edition = "2018"
 
+[badges]
+travis-ci = { repository = "RusPiRo/ruspiro-singleton", branch = "master" }
+maintenance = { status = "actively-developed" }
+
 [lib]
 
 [dependencies]
 ruspiro-lock = "0.2"
-ruspiro-interrupt-core = "0.2"
 
 [features]
 


### PR DESCRIPTION
interrupt's are disabled with the spinlock that is guarding the singleton access. So, no additional disabling/enabling of interrupts is necessary in the singleton accessor (take_for).